### PR TITLE
Re-order JS include tags

### DIFF
--- a/lib/assets/_footer.html
+++ b/lib/assets/_footer.html
@@ -39,6 +39,7 @@
       </div>
     </div>
   </body>
+  <%= javascript_include_tag "txi_rails_hologram/application" %>
   <%= javascript_include_tag "application" %>
   <!--[if (lte IE 9)]>
     <%= javascript_include_tag "application-ltie10" %>
@@ -68,5 +69,4 @@
 
     }).call(this);
   </script>
-  <%= javascript_include_tag "txi_rails_hologram/application" %>
 </html>


### PR DESCRIPTION
This moves the txi-rails-hologram JS first (before the application-specific JS), so as to avoid jQuery conflicts.