### PR TITLE
Add support for app-specific styleguide CSS and JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TxiRailsHologram
 
+## Overview
+
 This gem integrates [hologram](https://github.com/trulia/hologram) with [rails](https://github.com/rails/rails) for generating a [living style guide](http://alistapart.com/article/creating-style-guides).
 
 This gem provides a Rails-aware [haml](http://haml.info/) renderer. This renderer allows code examples that
@@ -69,8 +71,27 @@ This gem provides a Rails-aware [haml](http://haml.info/) renderer. This rendere
 
 3. Whenever you want to generate the styleguide, run `rake txi_rails_hologram:build` from your Rails app's root.
 
-## Overrides
+## Customization
 
-If the default `_header.html` and `_footer.html` provided by this gem don't suit you, you can set `documentation_assets` in your `hologram_config.yml` to a local folder inside your Rails project. This gem will then use those files, instead of the default ones it provides.
+### Assets
+
+Since different projects load different assets (JS and CSS), you can specify what to load in your styleguide. Set the `styleguide_head` and/or `styleguide_foot` options in your `hologram_config.yml` to a path relative to your `Rails.root`, and this gem will read a [haml](http://haml.info/) file at that location in order to pick up the content.
+
+Example:
+
+```yaml
+styleguide_head: ./styleguide/assets/_head.html.haml
+```
+
+```haml
+-# styleguide/assets/_head.html.haml
+= stylesheet_link_tag 'application'
+```
+
+If these options are not specified, this gem will use the default head and foot from `lib/assets/`.
+
+### Header and Footer
+
+If the default `_header.html` and `_footer.html` provided by this gem simply don't suit you at all, you can set `documentation_assets` in your `hologram_config.yml` to a local folder inside your Rails project. This gem will then use _those_ files, instead of the default ones it provides.
 
 In those files, you can use _some_ helpers, just as you would in a normal Rails layout. See `lib/txi_rails_hologram/template_variables_ext.rb` for what's currently implemented.

--- a/lib/assets/_default_styleguide_foot.html.haml
+++ b/lib/assets/_default_styleguide_foot.html.haml
@@ -1,0 +1,6 @@
+= javascript_include_tag "application-foot"
+
+/[if (lte IE 9)]
+  = javascript_include_tag "application-foot-ltie10"
+
+= javascript_include_tag "application-defer.js", async: true

--- a/lib/assets/_default_styleguide_head.html.haml
+++ b/lib/assets/_default_styleguide_head.html.haml
@@ -1,0 +1,4 @@
+= stylesheet_link_tag "application", media: "screen"
+= stylesheet_link_tag "application-print", media: "print"
+
+= javascript_include_tag "application-head"

--- a/lib/assets/_footer.html
+++ b/lib/assets/_footer.html
@@ -39,34 +39,7 @@
       </div>
     </div>
   </body>
+
   <%= javascript_include_tag "txi_rails_hologram/application" %>
-  <%= javascript_include_tag "application" %>
-  <!--[if (lte IE 9)]>
-    <%= javascript_include_tag "application-ltie10" %>
-  <![endif]-->
-  <script>
-    (function() {
-      var downloadJSAtOnload, preExistingOnload;
-
-      downloadJSAtOnload = function() {
-        var element;
-        element = document.createElement("script");
-        element.src = '<%= asset_path("application-defer.js") %>';
-        return document.body.appendChild(element);
-      };
-
-      if (window.addEventListener) {
-        window.addEventListener("load", downloadJSAtOnload, false);
-      } else if (window.attachEvent) {
-        window.attachEvent("onload", downloadJSAtOnload);
-      } else {
-        preExistingOnload = window.onload;
-        window.onload = function() {
-          setTimeout(downloadJSAtOnload, 0);
-          return typeof preExistingOnload === "function" ? preExistingOnload() : void 0;
-        };
-      }
-
-    }).call(this);
-  </script>
+  <%= application_specific_styleguide_foot %>
 </html>

--- a/lib/assets/_header.html
+++ b/lib/assets/_header.html
@@ -12,8 +12,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
     <%= stylesheet_link_tag "txi_rails_hologram/application" %>
-    <%= stylesheet_link_tag "application" %>
-    <%= javascript_include_tag "application-head" %>
+    <%= application_specific_styleguide_head %>
   </head>
   <body class="sg--body">
     <div class="sg--wrapper">

--- a/lib/txi_rails_hologram/rendering_context.rb
+++ b/lib/txi_rails_hologram/rendering_context.rb
@@ -1,10 +1,12 @@
+require "haml"
+
 module TxiRailsHologram
 
   # Public: A context for rendering HAML that knows about helpers from Rails,
   # gems and the current application.
   class RenderingContext
 
-    # Public: Creates a new context into which we can render a chunk of HAML.
+    # Internal: Creates a new context into which we can render a chunk of HAML.
     #
     # Returns a properly-configured instance of ActionView::Base.
     def self.create
@@ -31,13 +33,74 @@ module TxiRailsHologram
       view_context.view_paths = controller.view_paths
       view_context.controller = controller
 
-      view_context
+
+      # Add support for capturing HAML via the helpers module.
+      class << view_context; include Haml::Helpers; end
+
+      # This call is needed since we're outside the typical Rails setup. See:
+      # https://github.com/haml/haml/blob/88110b0607efca433c13bb1e339dcb1131edf010/lib/haml/helpers.rb#L56-L70
+      view_context.init_haml_helpers
+
+      ViewContextWrapper.new(view_context)
     end
     private_class_method :create
 
-    # A Singleton instance of the context.
+    # Public: A Singleton instance of the context.
     def self.instance
       @instance ||= create
+    end
+
+    # Public: A decorator around an ActionView::Base object that provides some
+    # custom functionality around loading assets that are specific to this
+    # gem's host application. This allows us to account for variance in setup
+    # of CSS and JS files across projects.
+    class ViewContextWrapper < SimpleDelegator
+
+      # Public: The content that should be loaded in the <head> for the
+      # particular host application.
+      #
+      # Returns a String.
+      def application_specific_styleguide_head
+        render_assets(config["styleguide_head"], "lib/assets/_default_styleguide_head.html.haml")
+      end
+
+      # Public: The content that should be loaded in the foot (right before the
+      # closing </body> tag) of the particular host application.
+      #
+      # Returns a String.
+      def application_specific_styleguide_foot
+        render_assets(config["styleguide_foot"], "lib/assets/_default_styleguide_foot.html.haml")
+      end
+
+      private
+
+      # Internal: The configuration from the hologram_config.yml file of the
+      # host application.
+      #
+      # Returns a Hash.
+      def config
+        @config ||= YAML.load(File.read(Rails.root.join("hologram_config.yml")))
+      end
+
+      # Internal: Renders the HAML content at the app_file_path or fallback_path.
+      #
+      # app_file_path - A String path relative to the host application's
+      #                 Rails.root, e.g. `styleguide/assets/_head.html.haml`
+      # fallback_path - A String path relative to the gem's root, e.g.
+      #                 `lib/assets/_default_head.html.haml`
+      #
+      # Returns a String.
+      def render_assets(app_file_path, fallback_path)
+        if app_file_path
+          content = File.read(Rails.root.join(app_file_path))
+        else
+          gem_path = Bundler.rubygems.find_name("txi_rails_hologram").first.full_gem_path
+          content = File.read("#{gem_path}/#{fallback_path}")
+        end
+
+        engine = Haml::Engine.new(content)
+        engine.render(self)
+      end
     end
 
   end

--- a/lib/txi_rails_hologram/template_variables_ext.rb
+++ b/lib/txi_rails_hologram/template_variables_ext.rb
@@ -7,8 +7,14 @@ Hologram::TemplateVariables.class_eval do
 
   def_delegators(
     "TxiRailsHologram::RenderingContext.instance",
+
+    # Rails-specific:
     :stylesheet_link_tag,
     :javascript_include_tag,
     :asset_path,
+
+    # Our own custom functionality:
+    :application_specific_styleguide_head,
+    :application_specific_styleguide_foot,
   )
 end

--- a/spec/dummy/hologram_config.yml
+++ b/spec/dummy/hologram_config.yml
@@ -25,3 +25,5 @@ nav_level: all
 # If you want Hologram to exit on these warnings, set the value to 'true'
 # (Default value is 'false')
 exit_on_warnings: false
+
+styleguide_foot: styleguide/assets/_custom_foot.html.haml

--- a/spec/dummy/styleguide/assets/_custom_foot.html.haml
+++ b/spec/dummy/styleguide/assets/_custom_foot.html.haml
@@ -1,0 +1,1 @@
+Custom foot

--- a/spec/lib/txi_rails_hologram/builder_spec.rb
+++ b/spec/lib/txi_rails_hologram/builder_spec.rb
@@ -8,15 +8,24 @@ describe TxiRailsHologram::Builder do
   describe "#build" do
     context "with valid params" do
       let(:destination) { Dir.mktmpdir }
-
-      it "creates a styleguide" do
+      before do
         config = {
           "source" => [Rails.root.join("app/assets/stylesheets")],
           "destination" => destination,
         }
         subject.build(config)
+      end
 
+      it "creates a styleguide" do
         expect(File.exist?(File.join(destination, "basics.html"))).to be_truthy
+      end
+
+      it "puts in the default head" do
+        expect(File.read(File.join(destination, "basics.html"))).to match(/application.*\.css/)
+      end
+
+      it "puts in a custom foot" do
+        expect(File.read(File.join(destination, "basics.html"))).to match(/custom/i)
       end
     end
 


### PR DESCRIPTION
This PR adds support for defining a host-application-specific setup for what CSS/JS files should be included in the "head" and "foot" of the styleguide. This customization allows the gem to work with a much wider range of existing (and future) projects, without having to default to the tactic of overriding the `_header` and `_footer` files entirely.