### PR TITLE
Bump version number

### DIFF
--- a/lib/txi_rails_hologram/version.rb
+++ b/lib/txi_rails_hologram/version.rb
@@ -2,6 +2,6 @@
 module TxiRailsHologram
 
   # Public: The version of this gem.
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 
 end


### PR DESCRIPTION
We missed bumping the version number in PR #7. This should remedy that and allow Bundler to update the gem properly.
